### PR TITLE
Typo. this should compare against getDeviceConnectionStatus()

### DIFF
--- a/src/main/java/com/notnoop/mpns/internal/Utilities.java
+++ b/src/main/java/com/notnoop/mpns/internal/Utilities.java
@@ -115,7 +115,7 @@ public final class Utilities {
             }
 
             if (r.getDeviceConnectionStatus() != null
-                && !r.getNotificationStatus().equals(headerValue(response, "X-DeviceConnectionStatus"))) {
+                && !r.getDeviceConnectionStatus().equals(headerValue(response, "X-DeviceConnectionStatus"))) {
                 continue;
             }
 


### PR DESCRIPTION
This prevents a match on a successful delivery and MpnsDelegate.messageSent() is not called.
