### PR TITLE
Fix a wrong method call in logicalResponseFor

### DIFF
--- a/src/main/java/com/notnoop/mpns/internal/Utilities.java
+++ b/src/main/java/com/notnoop/mpns/internal/Utilities.java
@@ -115,7 +115,7 @@ public final class Utilities {
             }
 
             if (r.getDeviceConnectionStatus() != null
-                && !r.getNotificationStatus().equals(headerValue(response, "X-DeviceConnectionStatus"))) {
+                && !r.getDeviceConnectionStatus().equals(headerValue(response, "X-DeviceConnectionStatus"))) {
                 continue;
             }
 


### PR DESCRIPTION
Changed `r.getNotificationStatus()` to `r.getDeviceConnectionStatus()` in the third check of the `logicalResponseFor` method.
